### PR TITLE
Fixed thrown error

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ exports.hook_lookup_rdns = function onLookup (next, connection) {
     const plugin = this;
     if (connection.remote.is_private) return next();
 
-    if (!connection.server.notes.p0f_client) {
+    if (connection.server && (!connection.server.notes || !connection.server.notes.p0f_client)) {
         connection.logerror(plugin, 'missing server');
         return next();
     }


### PR DESCRIPTION
When running the following test, an error was being thrown:
haraka -c /etc/haraka -t p0f
[CRIT] [BC8475EE-E073-408F-947F-9A4B7C217505] [core] Plugin p0f failed: TypeError: Cannot read property 'p0f_client' of undefined
