### PR TITLE
Missing connect arg

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+### [1.0.9] - 2022-11-10
+
+- fix connect path argument causing server crash when socket missing
 
 ### [1.0.8] - 2022-07-07
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class P0FClient {
 
             // Try and reconnect
             if (!this.restart_interval) {
-                this.restart_interval = setInterval(() => { this.connect(); }, 5 * 1000);
+                this.restart_interval = setInterval(() => { this.connect(path); }, 5 * 1000);
             }
             // Clear the receive queue
             for (let i=0; i<this.receive_queue.length; i++) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-p0f",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Haraka plugin that adds TCP fingerprinting",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
-  fix connect path argument causing server crash when socket missing

Issue:
```
[CRIT] [-] [core] TypeError [ERR_MISSING_ARGS]: The "options" or "port" or "path" argument must be specified
[CRIT] [-] [core] at new NodeError (node:internal/errors:371:5)
[CRIT] [-] [core] at Socket.connect (node:net:953:11)
[CRIT] [-] [core] at Object.connect (node:net:203:17)
[CRIT] [-] [core] at P0FClient.connect (/usr/lib/node_modules/Haraka/node_modules/haraka-plugin-p0f/index.js:22:25)
[CRIT] [-] [core] at Timeout._onTimeout (/usr/lib/node_modules/Haraka/node_modules/haraka-plugin-p0f/index.js:53:66)
[CRIT] [-] [core] at listOnTimeout (node:internal/timers:559:17)
[CRIT] [-] [core] at processTimers (node:internal/timers:502:7)
[NOTICE] [-] [core] Shutting down
```
